### PR TITLE
Redirect to aasx-core-works

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,6 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <option name="RIGHT_MARGIN" value="88" />
+    <option name="SOFT_MARGINS" value="88" />
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This collection of documents captures the design decisions we made while discussing and designing the aasx-core library.
 
-The documentation is available on https://admin-shell-io.github.io/aasx-core-design-docs/.
+The documentation is available on https://aasx-core-works.github.io/design-docs/.
 
 ## A Note about Validity
 


### PR DESCRIPTION
This patch updates the links to lead to aasx-core-works instead of
admin-shell-io GitHub organization.